### PR TITLE
Refactors the codebase to match NEP-413

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,133 +1,196 @@
 # near-sign-verify
 
-Creates and validates NEAR signatures for API authentication.
+Creates and validates NEAR signatures for API authentication, with alignment to [NEP-413] for message signing.
 
 ```bash
 npm install near-sign-verify
 ```
 
+## Features
+
+*   Sign messages with a KeyPair or a NEP-413 compliant wallet.
+*   Verify signed messages with robust options.
+*   Support for custom nonce generation and validation.
+*   Support for `state` parameter for CSRF protection (NEP-413).
+*   Sign any serializable message content (strings, objects, etc.).
+*   Flexible recipient validation.
+*   Provides NEP-413 core types (`SignMessageParams`, `SignedMessage`, `SignedPayload`) for interoperability.
+
 ## with KeyPair
 
-Works with both full access and function call access keys.
+Works with both full access and function call access keys (configurable in `verify` options).
 
 ```typescript
 // --- Create request with signed token ---
-import { sign } from "near-sign-verify";
-import { KeyPair } from '@near-js/crypto';
+import { sign, verify, type VerificationResult } from "near-sign-verify";
+import { KeyPair } from '@near-js/crypto'; // Or your preferred crypto library
 
 const keyPair = KeyPair.fromRandom('ed25519'); // for example
 
-const authToken = await sign({
+// Example 1: Signing a simple string message
+const authTokenString = await sign({
   signer: keyPair.toString(),
-  accountId: "you.near", // PubKey owner (you can pretend)
+  accountId: "you.near", // PubKey owner
   recipient: "your-service.near",
-  message: "login attempt"
+  message: "login attempt",
+  state: "client-generated-csrf-token" // Optional state parameter
 });
 
-// --- Send request with the token ---
+// Example 2: Signing a structured message object
+interface MyLoginMessage {
+  action: string;
+  timestamp: number;
+  details?: string;
+}
 
+const structuredMessage: MyLoginMessage = {
+  action: "authenticateUser",
+  timestamp: Date.now(),
+  details: "User initiated login via web form"
+};
+
+const authTokenObject = await sign<MyLoginMessage>({
+  signer: keyPair.toString(),
+  accountId: "you.near",
+  recipient: "your-service.near",
+  message: structuredMessage,
+  state: "another-csrf-token",
+  // messageSerializer: (msg) => JSON.stringify(msg) // Default for non-string messages
+});
+
+
+// --- Send request with the token ---
 fetch('https://api.example.com/endpoint', {
-  headers: { 'Authorization': `Bearer ${authToken}` },
+  headers: { 'Authorization': `Bearer ${authTokenString}` }, // or authTokenObject
 });
 
 // --- Verify the token ---
 
+// Verifying the string message token
 try {
-  const result = await verify(authToken, {
+  const result: VerificationResult<string> = await verify(authTokenString, {
     expectedRecipient: "your-service.near", // Ensure token is for your service
-    requireFullAccessKey: false,  // Allow Function Call Access Keys
+    // requireFullAccessKey: true, (default) // Set to false to allow Function Call Access Keys
     nonceMaxAge: 300000,          // 5 minutes since message signed
+    expectedState: "client-generated-csrf-token" // Validate the state
   });
 
-  // If verification is successful, you get a VerificationResult
-  console.log('Successfully verified for account:', result.accountId);
-  // you.near
-  console.log('Message from token:', result.message);
-  // { customInfo: 'login attempt' }
+  console.log('Successfully verified for account:', result.accountId); // you.near
+  console.log('Message from token:', result.message); // "login attempt"
+  console.log('State from token:', result.state); // "client-generated-csrf-token"
 
 } catch (error: any) {
-  // If verification fails, an error is thrown
+  console.error('Token verification failed:', error.message);
+}
+
+// Verifying the structured message token
+try {
+  const resultObj: VerificationResult<MyLoginMessage> = await verify<MyLoginMessage>(authTokenObject, {
+    expectedRecipient: "your-service.near",
+    nonceMaxAge: 300000,
+    expectedState: "another-csrf-token",
+    // messageParser: (msgStr) => JSON.parse(msgStr) // Default for non-string messages
+  });
+
+  console.log('Successfully verified object message for account:', resultObj.accountId);
+  console.log('Parsed Message from token:', resultObj.message.action, resultObj.message.timestamp);
+  // "authenticateUser", 167...
+
+} catch (error: any) {
   console.error('Token verification failed:', error.message);
 }
 ```
 
-## with fastintear
+## with a Wallet (NEP-413 Compliant)
 
-Uses [fastintear](https://github.com/elliotBraem/fastintear), an expirmental fork of [@fastnear/js-monorepo](https://github.com/fastnear/js-monorepo) -- an alternative to [near-api-js](https://github.com/near/near-api-js) and [near-wallet-selector](https://github.com/near/wallet-selector).
+Uses a wallet object that implements the `WalletInterface` (which expects `signMessage` to conform to NEP-413 `SignMessageParams` and `SignedMessage`).
 
 ```typescript
-import * as near from "fastintear";
-import { sign, verify } from 'near-sign-verify';
+import { sign, verify, type WalletInterface, type SignMessageParams, type SignedMessage, type VerificationResult } from 'near-sign-verify';
+
+// Assume 'wallet' is an object implementing WalletInterface
+// const wallet: WalletInterface = ...;
 
 const authToken = await sign({
-  signer: near, // has a signMessage function
+  signer: wallet, // Wallet object
   recipient: 'app.near',
-  message: "login attempt" // whatever message, can be validated on backend
+  message: "user action confirmation",
+  state: "wallet-session-state"
 });
 
 // --- Send request with the token ---
-
-fetch('https://api.example.com/endpoint', {
-  headers: { 'Authorization': `Bearer ${authToken}` },
-});
+// ... (same as above)
 
 // --- Verify the token ---
-
 try {
-  const result = await verify(authToken, {
-    expectedRecipient: "your-service.near", // Ensure token is for your service
-    // by default, wallet ensures a full access key (will always work)
-    nonceMaxAge: 300000,                    // 5 minutes since message signed
+  const result: VerificationResult = await verify(authToken, {
+    expectedRecipient: "app.near",
+    // requireFullAccessKey: true, // Default
+    nonceMaxAge: 300000,
+    expectedState: "wallet-session-state",
+    // Example of custom recipient validation
+    validateRecipient: (receivedRecipient) => {
+      const allowedRecipients = ["app.near", "staging.app.near"];
+      return allowedRecipients.includes(receivedRecipient);
+    }
   });
 
-  // If verification is successful, you get a VerificationResult
-  console.log('Successfully verified for account:', result.accountId);
-  // you.near
-  console.log('Message from token:', result.message);
-  // { customInfo: 'login attempt' }
+  console.log('Successfully verified with wallet for account:', result.accountId);
+  console.log('Message:', result.message);
 
 } catch (error: any) {
-  // If verification fails, an error is thrown
   console.error('Token verification failed:', error.message);
 }
 ```
 
-## with custom nonce + validation
+## Custom Nonce and Validation
 
-You can override the default nonce generation and validation (timestamp based, maxAge):
+You can override the default nonce generation (timestamp-based) and validation.
 
 ```typescript
-import { sign, verify } from "near-sign-verify";
+import { sign, verify, generateNonce } from "near-sign-verify";
+
+// Example: Using a custom Uint8Array nonce
+const customNonce = generateNonce(); // Or your own 32-byte Uint8Array
 
 const authToken = await sign({
-  signer: wallet,
+  signer: wallet, // or keyPair.toString()
+  accountId: "test.near", // if using keypair
   recipient: "your-service.near",
-  nonce: 1, // your nonce override
-  message: "do something" // whatever message, can be validated on backend
-})
+  nonce: customNonce, // Provide your 32-byte Uint8Array
+  message: "do something with custom nonce"
+});
 
 try {
   const result = await verify(authToken, {
     expectedRecipient: "your-service.near",
-    validateNonce: (nonce: Uint8Array): boolean => {
-      // do something
-      return true;
+    validateNonce: (nonceFromToken: Uint8Array): boolean => {
+      // Your custom validation logic, e.g., check against a list of used nonces
+      console.log("Validating nonce:", nonceFromToken);
+      // For this example, just ensure it matches the one we sent (not a real validation)
+      return nonceFromToken.every((val, idx) => val === customNonce[idx]);
     }
   });
-  // optionally validate the message
-  const message = result.message;
-} catch {
-  // failed
+  console.log('Message with custom nonce:', result.message);
+} catch (error: any) {
+  console.error('Verification with custom nonce failed:', error.message);
 }
 ```
 
-## debugging
+## Debugging
 
-You can use the `parseAuthToken` helper method to inspect the outcome of `sign`.
+You can use the `parseAuthToken` helper method to inspect the content of the generated token.
 
 ```typescript
+import { parseAuthToken, type NearAuthTokenPayload } from "near-sign-verify";
 
-import { parseAuthToken, type NearAuthData } from "near-sign-verify";
-
-const authData: NearAuthData = parseAuthToken(authToken);
+// Assuming authToken is a string from sign()
+const tokenData: NearAuthTokenPayload = parseAuthToken(authToken);
+console.log("Decoded token data:", tokenData);
+// Access fields like tokenData.signed_message_content, tokenData.state, etc.
 ```
+
+## NEP-413 Alignment
+
+This library aims to be compatible with the signing and verification logic outlined in [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md).
+It exports core NEP-413 types like `SignMessageParams`, `SignedMessage`, and `SignedPayload` for developers who might need them for deeper integration or wallet development. The `WalletInterface` is designed around these NEP-413 types.

--- a/src/auth/authTokenSchema.ts
+++ b/src/auth/authTokenSchema.ts
@@ -1,32 +1,46 @@
-import type { NearAuthData } from "../types.js";
+import type { NearAuthTokenPayload } from "../types.js";
 
 /**
- * Borsh schema for NearAuthData
+ * Borsh schema for NearAuthTokenPayload.
+ * This is the structure that is serialized and encoded into the final authTokenString.
  */
-export const nearAuthDataBorshSchema = {
+export const nearAuthTokenPayloadBorshSchema = {
   struct: {
     account_id: "string",
     public_key: "string",
-    signature: "string",
-    message: "string",
-    nonce: { array: { type: "u8", len: 32 } },
-    recipient: "string",
-    callback_url: { option: "string" },
+    signature: "string", // Base64 of raw signature
+
+    // Fields that were part of the signed SignedPayload
+    signed_message_content: "string",
+    signed_nonce: { array: { type: "u8", len: 32 } },
+    signed_recipient: "string",
+    signed_callback_url: { option: "string" },
+
+    // Additional metadata for the token (not part of the signature hash)
+    state: { option: "string" },
+    original_message_representation: { option: "string" },
   },
 };
 
 /**
- * Helper function to prepare data for Borsh serialization
- * (handling optional fields properly)
+ * Helper function to prepare NearAuthTokenPayload data for Borsh serialization,
+ * ensuring optional fields are correctly represented (e.g., as null if undefined).
+ * @param tokenPayload The NearAuthTokenPayload object.
+ * @returns An object suitable for Borsh serialization.
  */
-export function prepareBorshData(authData: NearAuthData): any {
+export function prepareNearAuthTokenPayloadForBorsh(
+  tokenPayload: NearAuthTokenPayload,
+): any {
   return {
-    account_id: authData.account_id,
-    public_key: authData.public_key,
-    signature: authData.signature,
-    message: authData.message,
-    nonce: authData.nonce,
-    recipient: authData.recipient,
-    callback_url: authData.callback_url || null,
+    account_id: tokenPayload.account_id,
+    public_key: tokenPayload.public_key,
+    signature: tokenPayload.signature,
+    signed_message_content: tokenPayload.signed_message_content,
+    signed_nonce: tokenPayload.signed_nonce,
+    signed_recipient: tokenPayload.signed_recipient,
+    signed_callback_url: tokenPayload.signed_callback_url ?? null,
+    state: tokenPayload.state ?? null,
+    original_message_representation:
+      tokenPayload.original_message_representation ?? null,
   };
 }

--- a/src/auth/createAuthToken.ts
+++ b/src/auth/createAuthToken.ts
@@ -1,20 +1,23 @@
 import * as borsh from "borsh";
-import type { NearAuthData } from "../types.js";
+import type { NearAuthTokenPayload } from "../types.js";
 import { uint8ArrayToBase64 } from "../utils/encoding.js";
 import {
-  nearAuthDataBorshSchema,
-  prepareBorshData,
+  nearAuthTokenPayloadBorshSchema,
+  prepareNearAuthTokenPayloadForBorsh,
 } from "./authTokenSchema.js";
 
 /**
  * Create properly formatted auth token for API authentication
- * @param authData NEAR authentication data
- * @returns Auth token string (Base64 encoded Borsh serialized data)
+ * @param tokenPayload The payload containing all necessary data for the token.
+ * @returns Auth token string (Base64 encoded Borsh serialized NearAuthTokenPayload)
  */
-export function createAuthToken(authData: NearAuthData): string {
-  const borshData = prepareBorshData(authData);
+export function createAuthToken(tokenPayload: NearAuthTokenPayload): string {
+  const borshData = prepareNearAuthTokenPayloadForBorsh(tokenPayload);
 
-  const serialized = borsh.serialize(nearAuthDataBorshSchema, borshData);
+  const serialized = borsh.serialize(
+    nearAuthTokenPayloadBorshSchema,
+    borshData,
+  );
 
   return uint8ArrayToBase64(serialized);
 }

--- a/src/auth/parseAuthToken.ts
+++ b/src/auth/parseAuthToken.ts
@@ -1,41 +1,55 @@
 import * as borsh from "borsh";
-import { z } from "zod";
-import {
-  NearAuthDataSchema,
-  type NearAuthData,
-  type BorshNearAuthData,
-} from "../types.js";
+// import { z } from "zod"; // Zod validation removed for now, can be re-added for NearAuthTokenPayload
+import type { NearAuthTokenPayload } from "../types.js";
 import { base64ToUint8Array } from "../utils/encoding.js";
-import { createValidationErrorMessage } from "../utils/validation.js";
-import { nearAuthDataBorshSchema } from "./authTokenSchema.js";
+// import { createValidationErrorMessage } from "../utils/validation.js"; // If Zod is re-added
+import { nearAuthTokenPayloadBorshSchema } from "./authTokenSchema.js";
 
 /**
- * Parse a NEAR auth token into NearAuthData
- * @param authToken The authorization token string (Base64 encoded Borsh serialized data)
- * @returns NearAuthData
- * @throws Error if the token is invalid or missing required fields
+ * Parse a NEAR auth token into NearAuthTokenPayload.
+ * @param authToken The authorization token string (Base64 encoded Borsh serialized NearAuthTokenPayload).
+ * @returns NearAuthTokenPayload.
+ * @throws Error if the token is invalid or deserialization fails.
  */
-export function parseAuthToken(authToken: string): NearAuthData {
+export function parseAuthToken(authToken: string): NearAuthTokenPayload {
   try {
     // Convert from Base64 and deserialize using Borsh
     const serialized = base64ToUint8Array(authToken);
     const deserialized = borsh.deserialize(
-      nearAuthDataBorshSchema,
+      nearAuthTokenPayloadBorshSchema,
       serialized,
-    ) as BorshNearAuthData;
+    ) as NearAuthTokenPayload; // Assuming direct deserialization to the target type
 
     if (!deserialized) {
-      throw new Error("Deserialization failed: null result");
+      throw new Error("Deserialization failed: result is null or undefined.");
     }
 
-    // Validate and transform with Zod schema (handles nonce conversion)
-    return NearAuthDataSchema.parse(deserialized);
-  } catch (error) {
-    if (error instanceof z.ZodError) {
+    // Ensure signed_nonce is a Uint8Array, as Borsh might return a plain array of numbers
+    // depending on the exact 'borsh' library version and schema definition.
+    // The schema { array: { type: "u8", len: 32 } } should handle this, but a check can be good.
+    if (
+      !(deserialized.signed_nonce instanceof Uint8Array) &&
+      Array.isArray(deserialized.signed_nonce)
+    ) {
+      deserialized.signed_nonce = new Uint8Array(deserialized.signed_nonce);
+    } else if (!(deserialized.signed_nonce instanceof Uint8Array)) {
+      // This case should ideally not happen if deserialization is correct
+      // and schema enforces Uint8Array or a structure convertible to it.
       throw new Error(
-        `Invalid auth data: ${createValidationErrorMessage(error)}`,
+        "Deserialized signed_nonce is not a Uint8Array or an array of numbers.",
       );
     }
+
+
+    // TODO: Consider re-adding Zod validation for NearAuthTokenPayload if complex validation rules are needed.
+    // For now, we rely on Borsh deserialization and type casting.
+    return deserialized;
+  } catch (error) {
+    // if (error instanceof z.ZodError) { // If Zod is re-added
+    //   throw new Error(
+    //     `Invalid auth data: ${createValidationErrorMessage(error)}`,
+    //   );
+    // }
     if (error instanceof Error) {
       throw new Error(
         `Invalid auth token: ${error.message.replace(/^Error: /, "")}`,

--- a/src/auth/sign.ts
+++ b/src/auth/sign.ts
@@ -1,154 +1,208 @@
 import { fromBase58, toBase58 } from "@fastnear/utils";
 import { ed25519 } from "@noble/curves/ed25519";
-import {
-  ED25519_PREFIX,
-  hashPayload,
-  serializePayload,
-  TAG,
-} from "../crypto/crypto.js";
+import { ED25519_PREFIX, TAG, hashForSigning } from "../crypto/crypto.js";
 import type {
-  NearAuthData,
-  NearAuthPayload,
   SignOptions,
   WalletInterface,
+  SignMessageParams,
+  SignedPayload,
+  NearAuthTokenPayload,
+  SignedMessage,
 } from "../types.js";
 import { uint8ArrayToBase64 } from "../utils/encoding.js";
 import { generateNonce } from "../utils/nonce.js";
 import { createAuthToken } from "./createAuthToken.js";
 
-interface InternalSignParameters {
-  message: string;
-  recipient: string;
-  nonce: Uint8Array; // Actual nonce bytes
-  callbackUrl?: string | null;
+// Helper to ensure nonce is Uint8Array
+function normalizeNonce(nonceInput?: Uint8Array | number): Uint8Array {
+  if (nonceInput instanceof Uint8Array) {
+    if (nonceInput.length !== 32) {
+      throw new Error(
+        `Provided nonce Uint8Array must be 32 bytes, got ${nonceInput.length}`,
+      );
+    }
+    return nonceInput;
+  }
+  if (typeof nonceInput === "number") {
+    // If a number is provided, we could try to fit it into 32 bytes,
+    // but NEP-413 implies a random or more robust nonce.
+    // For now, let's rely on generateNonce() if a full Uint8Array isn't given,
+    // or throw if a number is given without a clear conversion strategy.
+    // Defaulting to generateNonce() if input is number might be unexpected.
+    // For simplicity, this example will use generateNonce() if no Uint8Array is passed.
+    // A more robust solution might involve specific conversion or clearer error handling.
+    console.warn(
+      "Numeric nonce provided; using generated nonce instead. For specific numeric nonces, provide as a 32-byte Uint8Array.",
+    );
+    return generateNonce();
+  }
+  return generateNonce(); // Default if undefined or unhandled type
 }
 
-async function _signWithKeyPair(
-  keyPair: string,
-  signerId: string,
-  params: InternalSignParameters,
-): Promise<string> {
-  const { message, recipient, nonce, callbackUrl } = params;
-
-  const payloadToSerialize: NearAuthPayload = {
-    tag: TAG,
-    message: message,
-    nonce,
-    receiver: recipient,
-    callback_url: callbackUrl || undefined,
-  };
-
-  const serializedPayload = serializePayload(payloadToSerialize);
-  const payloadHash = hashPayload(serializedPayload);
-
-  if (!keyPair.startsWith(ED25519_PREFIX)) {
-    throw new Error("Invalid KeyPair format: missing ed25519 prefix.");
+// Helper to serialize message
+function serializeMessage<TMessage>(
+  message: TMessage,
+  serializer?: (msg: TMessage) => string,
+): string {
+  if (typeof message === "string") {
+    return message;
   }
-  const privateKeyBase58 = keyPair.substring(ED25519_PREFIX.length);
-  const privateKeyBytes = fromBase58(privateKeyBase58);
-
-  if (privateKeyBytes.length !== 64) {
+  if (serializer) {
+    return serializer(message);
+  }
+  try {
+    return JSON.stringify(message);
+  } catch (e) {
     throw new Error(
-      `Expected decoded private key to be 64 bytes for Ed25519, got ${privateKeyBytes.length}`,
+      "Failed to serialize message to string. Provide a custom messageSerializer or ensure message is stringifiable.",
     );
   }
-  const seed = privateKeyBytes.slice(0, 32); // Extract the 32-byte seed
+}
 
-  const signedResult = ed25519.sign(payloadHash, seed);
+async function _signWithKeyPair<TMessage>(
+  keyPairString: string,
+  signerId: string,
+  options: SignOptions<TMessage>,
+  serializedMessage: string,
+  nonceBytes: Uint8Array,
+): Promise<string> {
+  const { recipient, callbackUrl, state } = options;
 
-  const actualSignatureB64 = uint8ArrayToBase64(signedResult);
+  const payload: SignedPayload = {
+    message: serializedMessage,
+    nonce: nonceBytes,
+    recipient: recipient,
+    callbackUrl: callbackUrl || undefined,
+  };
 
+  const payloadHash = hashForSigning(TAG, payload);
+
+  if (!keyPairString.startsWith(ED25519_PREFIX)) {
+    throw new Error("Invalid KeyPair format: missing ed25519 prefix.");
+  }
+  const privateKeyBase58 = keyPairString.substring(ED25519_PREFIX.length);
+  const privateKeyBytes = fromBase58(privateKeyBase58);
+
+  // Assuming privateKeyBytes from fromBase58 for ed25519 is the 32-byte seed or 64-byte seed+pubkey
+  // noble/ed25519 sign function expects a 32-byte private key (seed)
+  let seed: Uint8Array;
+  if (privateKeyBytes.length === 64) {
+    seed = privateKeyBytes.slice(0, 32); // Extract the 32-byte seed
+  } else if (privateKeyBytes.length === 32) {
+    seed = privateKeyBytes;
+  } else {
+    throw new Error(
+      `Expected decoded private key (seed) to be 32 or 64 bytes for Ed25519, got ${privateKeyBytes.length}`,
+    );
+  }
+
+  const rawSignature = ed25519.sign(payloadHash, seed);
+  const signatureB64 = uint8ArrayToBase64(rawSignature);
   const publicKeyBytes = ed25519.getPublicKey(seed);
   const publicKeyString = ED25519_PREFIX + toBase58(publicKeyBytes);
 
-  const nearAuthDataObject: NearAuthData = {
+  const tokenPayload: NearAuthTokenPayload = {
     account_id: signerId,
     public_key: publicKeyString,
-    signature: actualSignatureB64,
-    message: message,
-    // @ts-expect-error Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'
-    nonce: nonce,
-    recipient: recipient,
-    callback_url: callbackUrl || null,
+    signature: signatureB64,
+    signed_message_content: serializedMessage,
+    signed_nonce: nonceBytes,
+    signed_recipient: recipient,
+    signed_callback_url: callbackUrl || undefined,
+    state: state || undefined,
+    original_message_representation:
+      typeof options.message === "string" ? undefined : serializedMessage,
   };
 
-  return createAuthToken(nearAuthDataObject);
+  return createAuthToken(tokenPayload);
 }
 
-async function _signWithWallet(
+async function _signWithWallet<TMessage>(
   wallet: WalletInterface,
-  params: InternalSignParameters,
+  options: SignOptions<TMessage>,
+  serializedMessage: string,
+  nonceBytes: Uint8Array,
 ): Promise<string> {
-  const { message, recipient, nonce, callbackUrl } = params;
+  const { recipient, callbackUrl, state } = options;
 
-  const walletResult = await wallet.signMessage({
-    message,
-    nonce,
-    recipient,
-  });
-  // walletResult.signature is expected to be a string like "ed25519:Base58EncodedSignature"
-  // walletResult.publicKey is expected to be a string like "ed25519:Base58EncodedPublicKey"
-
-  const sigParts = walletResult.signature.split(":");
-  if (sigParts.length !== 2 || sigParts[0].toLowerCase() !== "ed25519") {
-    throw new Error(
-      `Unsupported signature format from wallet: ${walletResult.signature}. Expected "ed25519:<base58_signature>"`,
-    );
-  }
-  const base58EncodedSignature = sigParts[1];
-
-  // Decode the Base58 signature to get the raw 64-byte signature
-  const rawSignatureBytes = fromBase58(base58EncodedSignature);
-
-  // Base64 encode the raw signature bytes
-  const actualSignatureB64 = uint8ArrayToBase64(rawSignatureBytes);
-
-  const nearAuthDataObject: NearAuthData = {
-    account_id: walletResult.accountId,
-    public_key: walletResult.publicKey, // full "ed25519:<base58_pk>" string
-    signature: actualSignatureB64, // Base64 of the *raw* 64-byte signature
-    message: message, // JSON string from createMessage
-    // @ts-expect-error Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'Uint8Array<ArrayBuffer>'
-    nonce: nonce, // actualNonceBytes (Uint8Array)
+  const nepSignParams: SignMessageParams = {
+    message: serializedMessage,
     recipient: recipient,
-    callback_url: callbackUrl || null,
+    nonce: nonceBytes,
+    callbackUrl: callbackUrl || undefined,
+    state: state || undefined,
   };
 
-  return createAuthToken(nearAuthDataObject);
+  const walletSignedMessage: SignedMessage =
+    await wallet.signMessage(nepSignParams);
+
+  // Wallet is expected to return signature as base64 of raw signature per NEP-413 SignedMessage.
+  // If it returns "ed25519:<bs58_sig>", we'd need to convert it.
+  // For now, assume it's already base64 of raw.
+  // If not, the following logic would be needed:
+  // let signatureB64 = walletSignedMessage.signature;
+  // if (walletSignedMessage.signature.includes(':')) {
+  //   const sigParts = walletSignedMessage.signature.split(":");
+  //   if (sigParts.length === 2 && sigParts[0].toLowerCase() === "ed25519") {
+  //     const rawSignatureBytes = fromBase58(sigParts[1]);
+  //     signatureB64 = uint8ArrayToBase64(rawSignatureBytes);
+  //   } else {
+  //     throw new Error(`Unsupported signature format from wallet: ${walletSignedMessage.signature}`);
+  //   }
+  // }
+
+
+  const tokenPayload: NearAuthTokenPayload = {
+    account_id: walletSignedMessage.accountId,
+    public_key: walletSignedMessage.publicKey,
+    signature: walletSignedMessage.signature, // Assumed to be Base64 of raw signature
+    signed_message_content: serializedMessage,
+    signed_nonce: nonceBytes,
+    signed_recipient: recipient,
+    signed_callback_url: callbackUrl || undefined,
+    state: walletSignedMessage.state || state || undefined, // Prioritize state from wallet response if present
+    original_message_representation:
+      typeof options.message === "string" ? undefined : serializedMessage,
+  };
+
+  return createAuthToken(tokenPayload);
 }
 
 function detectSignerType(
   signer: string | WalletInterface,
 ): "keypair" | "wallet" {
-  if (typeof (signer as WalletInterface).signMessage === "function") {
+  if (
+    typeof signer === "object" &&
+    signer !== null &&
+    typeof (signer as WalletInterface).signMessage === "function"
+  ) {
     return "wallet";
   }
   if (typeof signer === "string" && signer.startsWith(ED25519_PREFIX)) {
     return "keypair";
   }
   throw new Error(
-    "Invalid signer: must be KeyPair or a wallet object with a signMessage method.",
+    "Invalid signer: must be a KeyPair string (e.g., 'ed25519:...') or a wallet object implementing WalletInterface.",
   );
 }
 
 /**
- * Signs a message using either a KeyPair or a wallet, creating a structured
- * message and producing a NEAR authentication token.
+ * Signs a message using either a KeyPair or a wallet, creating a NEAR authentication token
+ * compliant with aspects of NEP-413.
  *
- * @param options The signing options.
+ * @param options The signing options, including the message (can be generic type TMessage).
  * @returns A promise that resolves to the final AuthToken string.
  */
-export async function sign(options: SignOptions): Promise<string> {
-  const { signer, accountId, recipient, message, callbackUrl, nonce } = options;
+export async function sign<TMessage = string>(
+  options: SignOptions<TMessage>,
+): Promise<string> {
+  const { signer, accountId, message, messageSerializer, nonce } = options;
 
-  const currentNonce = nonce || generateNonce();
-
-  const internalParams: InternalSignParameters = {
+  const currentNonceBytes = normalizeNonce(nonce);
+  const serializedMessageForSigning = serializeMessage(
     message,
-    recipient: recipient,
-    nonce: currentNonce,
-    callbackUrl: callbackUrl,
-  };
+    messageSerializer,
+  );
 
   const signerType = detectSignerType(signer);
 
@@ -156,9 +210,20 @@ export async function sign(options: SignOptions): Promise<string> {
     if (!accountId) {
       throw new Error("accountId is required when using a KeyPair signer.");
     }
-    return _signWithKeyPair(signer as string, accountId, internalParams);
+    return _signWithKeyPair(
+      signer as string,
+      accountId,
+      options,
+      serializedMessageForSigning,
+      currentNonceBytes,
+    );
   } else {
-    // For wallet, accountId comes from the wallet's response, not from options.
-    return _signWithWallet(signer as WalletInterface, internalParams);
+    // WalletInterface
+    return _signWithWallet(
+      signer as WalletInterface,
+      options,
+      serializedMessageForSigning,
+      currentNonceBytes,
+    );
   }
 }

--- a/src/crypto/crypto.ts
+++ b/src/crypto/crypto.ts
@@ -1,47 +1,107 @@
 import { ed25519 } from "@noble/curves/ed25519";
 import { sha256 } from "@noble/hashes/sha2";
 import * as borsh from "borsh";
-import type { NearAuthPayload } from "../types.js";
+import type { SignedPayload } from "../types.js"; // Updated import
 import { fromBase58 } from "@fastnear/utils";
 
 export const ED25519_PREFIX = "ed25519:";
-export const TAG = 2147484061;
+export const TAG = 2147484061; // 2**31 + 413
 
 /**
- * Serialize a payload using Borsh
- * @param payload Payload to serialize
- * @returns Serialized payload as Uint8Array
+ * Borsh schema for the NEP-413 SignedPayload.
+ * This structure (message, nonce, recipient, callbackUrl) is what gets serialized,
+ * then prepended with the serialized TAG, and then hashed.
  */
-export function serializePayload(payload: NearAuthPayload): Uint8Array {
-  const borshPayload = {
-    tag: payload.tag,
+const signedPayloadBorshSchema = {
+  struct: {
+    message: "string",
+    nonce: { array: { type: "u8", len: 32 } },
+    recipient: "string",
+    callbackUrl: { option: "string" },
+  },
+};
+
+/**
+ * Hashes a payload according to NEP-413 specification for signing.
+ * This involves:
+ * 1. Serializing the TAG (u32, little-endian).
+ * 2. Serializing the `SignedPayload` (message, nonce, recipient, callbackUrl) using Borsh.
+ * 3. Concatenating `serializedTag + serializedSignedPayload`.
+ * 4. Computing the SHA-256 hash of the concatenated bytes.
+ * @param tag The NEP-413 tag (e.g., 2**31 + 413).
+ * @param payload The `SignedPayload` object.
+ * @returns The SHA-256 hash as a Uint8Array.
+ */
+export function hashForSigning(
+  tag: number,
+  payload: SignedPayload,
+): Uint8Array {
+  // 1. Serialize the TAG (as u32, little-endian)
+  const tagBytes = new Uint8Array(4);
+  new DataView(tagBytes.buffer).setUint32(0, tag, true); // true for little-endian
+
+  // 2. Serialize the SignedPayload
+  // Borsh expects nonce as ArrayLike<number>, ensure Uint8Array is converted if necessary by schema or here.
+  // The schema { array: { type: "u8", len: 32 } } should handle Uint8Array directly.
+  // Ensure optional callbackUrl is null if undefined for Borsh.
+  const borshCompatiblePayload = {
     message: payload.message,
-    nonce: Array.from(payload.nonce),
-    receiver: payload.receiver,
-    callback_url: payload.callback_url || null,
+    nonce: payload.nonce, // Schema should handle Uint8Array
+    recipient: payload.recipient,
+    callbackUrl: payload.callbackUrl ?? null,
   };
+  const serializedSignedPayload = borsh.serialize(
+    signedPayloadBorshSchema,
+    borshCompatiblePayload,
+  );
 
-  const schema = {
-    struct: {
-      tag: "u32",
-      message: "string",
-      nonce: { array: { type: "u8", len: 32 } },
-      receiver: "string",
-      callback_url: { option: "string" },
-    },
-  };
+  // 3. Concatenate them
+  const bytesToHash = new Uint8Array(
+    tagBytes.length + serializedSignedPayload.length,
+  );
+  bytesToHash.set(tagBytes, 0);
+  bytesToHash.set(serializedSignedPayload, tagBytes.length);
 
-  return borsh.serialize(schema, borshPayload);
+  // 4. Compute SHA-256 hash
+  return sha256(bytesToHash);
 }
 
-/**
- * Hash a payload using SHA-256
- * @param payload Payload to hash
- * @returns Hashed payload as Uint8Array
- */
-export function hashPayload(payload: Uint8Array): Uint8Array {
-  return sha256(payload);
-}
+// --- Old functions - potentially deprecated if no longer used by the new signing flow ---
+// /**
+//  * @deprecated This function serializes a payload structure that includes the tag internally.
+//  * NEP-413 requires the tag to be prepended to the serialized payload.
+//  * Consider using logic within `hashForSigning` for NEP-413 compliant serialization.
+//  */
+// export function serializePayload(payload: NearAuthPayload): Uint8Array {
+//   const borshPayload = {
+//     tag: payload.tag,
+//     message: payload.message,
+//     nonce: Array.from(payload.nonce),
+//     receiver: payload.receiver,
+//     callback_url: payload.callback_url || null,
+//   };
+
+//   const schema = {
+//     struct: {
+//       tag: "u32",
+//       message: "string",
+//       nonce: { array: { type: "u8", len: 32 } },
+//       receiver: "string",
+//       callback_url: { option: "string" },
+//     },
+//   };
+
+//   return borsh.serialize(schema, borshPayload);
+// }
+
+// /**
+//  * @deprecated This function hashes a pre-serialized payload.
+//  * For NEP-413, use `hashForSigning` which handles the specific NEP-413 hashing process.
+//  */
+// export function hashPayload(payload: Uint8Array): Uint8Array {
+//   return sha256(payload);
+// }
+// --- End of old functions ---
 
 /**
  * Verify a signature against a pre-computed payload hash.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,11 @@ export {
 
 // --- Core Types ---
 export type {
-  NearAuthData,
-  NearAuthPayload,
+  // NEP-413 Aligned Types
+  SignMessageParams,
+  SignedMessage,
+  SignedPayload,
+  // Library's main API types
   SignOptions,
   VerificationResult,
   VerifyOptions,


### PR DESCRIPTION
See NEP:

https://github.com/near/NEPs/blob/master/neps/nep-0413.md#why-using-a-fullaccess-key-why-not-simply-creating-an-functioncall-key-for-signing

Major changes:

- [ ] expose SignedMessageParams, SignedMessage types
- [ ] `sign(options: SignOptions)` -> `sign<TPayload>(payload: TPayload, options: SignOptions)`