### PR TITLE
Refactors the codebase to match NEP-413

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install near-sign-verify
 
 ### 1. Simple Client-Side Signing with a Wallet
 
-This example shows how to use `fastintear` (or any wallet object that implements `signMessage` as per NEP-413) to sign a message client-side, attach the token to an Authorization header, and verify it with default settings.
+This example shows how to use `fastintear` (or any wallet object that implements `signMessage` as per [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md)) to sign a message client-side, attach the token to an Authorization header, and verify it with default settings.
 
 This simple strategy is fine for a non-production application and provides a basic timestamp-based nonce validation.
 
@@ -70,9 +70,9 @@ try {
 
 ### 2. Signing with a KeyPair
 
-This flow demonstrates signing a message using a `KeyPair` directly. This is useful for testing, backend-initiated signing (if you manage keys securely), or simulated environments.
+This flow demonstrates signing a message using a `KeyPair` directly. This is useful for testing, backend-initiated signing (if you manage keys securely, such as when building a wallet), or simulated environments.
 
-**Important:** The NEP-413 standard explicitly states that messages **MUST be signed using a Full Access Key** for security. While `near-sign-verify` can verify signatures from Function Call Access Keys by setting `requireFullAccessKey: false`, this deviates from the NEP's core security premise and is **NOT recommended for production authentication flows** without significant additional validation on your end.
+**Important:** [NEP-413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md#why-using-a-fullaccess-key-why-not-simply-creating-an-functioncall-key-for-signing) standard explicitly states that messages **MUST be signed using a Full Access Key** for security. While `near-sign-verify` can verify signatures from Function Call Access Keys by setting `requireFullAccessKey: false`, this is **NOT recommended for production authentication flows** without significant additional validation on your end.
 
 ```typescript
 // --- Create signed token from KeyPair ---

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ import { KeyPair } from '@near-js/crypto';
 
 const keyPair = KeyPair.fromRandom('ed25519'); // for example
 
-const authToken = await sign({
+const authToken = await sign("login attempt", {
   signer: keyPair.toString(),
   accountId: "you.near", // PubKey owner (you can pretend)
-  recipient: "your-service.near",
-  message: "login attempt"
+  recipient: "your-service.near"
 });
 
 // --- Send request with the token ---
@@ -59,10 +58,9 @@ Uses [fastintear](https://github.com/elliotBraem/fastintear), an expirmental for
 import * as near from "fastintear";
 import { sign, verify } from 'near-sign-verify';
 
-const authToken = await sign({
+const authToken = await sign("login attempt", { // whatever message, can be validated on backend
   signer: near, // has a signMessage function
   recipient: 'app.near',
-  message: "login attempt" // whatever message, can be validated on backend
 });
 
 // --- Send request with the token ---
@@ -99,11 +97,10 @@ You can override the default nonce generation and validation (timestamp based, m
 ```typescript
 import { sign, verify } from "near-sign-verify";
 
-const authToken = await sign({
+const authToken = await sign("do something", { // whatever message, can be validated on backend
   signer: wallet,
   recipient: "your-service.near",
-  nonce: 1, // your nonce override
-  message: "do something" // whatever message, can be validated on backend
+  nonce: 1 // your nonce override
 })
 
 try {

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ POST("https://your-service.com/api/auth/verify-request", async (req, res) => {
     }
     res.status(400).json({ success: false, error: e.message });
   }
+});
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -1,26 +1,91 @@
-# near-sign-verify
+<!-- markdownlint-disable MD014 -->
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD029 -->
 
-Creates and validates NEAR signatures for API authentication.
+<div align="center">
+
+<h1 style="font-size: 2.5rem; font-weight: bold;">near-sign-verify</h1>
+
+  <p>
+    <strong>Create and validate <a href="https://github.com/near/NEPs/blob/master/neps/nep-0413.md" target="_blank">NEP-413</a> signed messages for API authentication</strong>
+  </p>
+
+</div>
 
 ```bash
 npm install near-sign-verify
 ```
 
-## with KeyPair
+> [!IMPORTANT]
+>
+> It is **highly recommended** that you implement state and nonce validation, initiated by a handshake with your backend. This crucial step helps mitigate [CSRF attacks](https://auth0.com/docs/secure/attack-protection/state-parameters) and [replay attacks](https://auth0.com/docs/get-started/authentication-and-authorization-flow/implicit-flow-with-form-post/mitigate-replay-attacks-when-using-the-implicit-flow). The [Full Backend Integration](#3-full-backend-integration-recommended-for-production) example below demonstrates this secure flow.
+>
 
-Works with both full access and function call access keys.
+## Cookbook
+
+### 1. Simple Client-Side Signing with a Wallet
+
+This example shows how to use `fastintear` (or any wallet object that implements `signMessage` as per NEP-413) to sign a message client-side, attach the token to an Authorization header, and verify it with default settings.
+
+This simple strategy is fine for a non-production application and provides a basic timestamp-based nonce validation.
 
 ```typescript
-// --- Create request with signed token ---
+import * as near from "fastintear"; // or any wallet object that implements signMessage
+import { sign, verify } from 'near-sign-verify';
+
+// --- Client-side: Create signed token from wallet ---
+
+const authToken = await sign("login attempt", {
+  signer: near, // has signMessage method
+  recipient: 'your-service.near', // can be a NEAR account ID or a URL/domain
+});
+
+// --- Client-side: Send request with the token ---
+
+fetch('https://api.example.com/endpoint', {
+  headers: { 'Authorization': `Bearer ${authToken}` },
+});
+
+// --- Server-side: Verify the token ---
+
+try {
+  const result = await verify(authToken, {
+    expectedRecipient: "your-service.near", // Ensure token is for your service
+    nonceMaxAge: 300000,                    // Nonce valid for 5 minutes since message signed
+    // expectedMessage: "login attempt",    // Optional: Validate the message content
+  });
+
+  // If verification is successful, you get a VerificationResult
+  console.log('Successfully verified for account:', result.accountId);
+  // Example: you.near
+  console.log('Message from token:', result.message);
+  // Example: 'login attempt' (or whatever message was originally signed)
+
+} catch (error: any) {
+  // If verification fails, an error is thrown
+  console.error('Token verification failed:', error.message);
+}
+```
+
+### 2. Signing with a KeyPair
+
+This flow demonstrates signing a message using a `KeyPair` directly. This is useful for testing, backend-initiated signing (if you manage keys securely), or simulated environments.
+
+**Important:** The NEP-413 standard explicitly states that messages **MUST be signed using a Full Access Key** for security. While `near-sign-verify` can verify signatures from Function Call Access Keys by setting `requireFullAccessKey: false`, this deviates from the NEP's core security premise and is **NOT recommended for production authentication flows** without significant additional validation on your end.
+
+```typescript
+// --- Create signed token from KeyPair ---
 import { sign } from "near-sign-verify";
 import { KeyPair } from '@near-js/crypto';
 
-const keyPair = KeyPair.fromRandom('ed25519'); // for example
+const fullAccessKeyPair = KeyPair.fromRandom('ed25519'); // example
+const accountId = "you.near"; // account associated with key pair
 
 const authToken = await sign("login attempt", {
-  signer: keyPair.toString(),
-  accountId: "you.near", // PubKey owner (you can pretend)
-  recipient: "your-service.near"
+  signer: fullAccessKeyPair.toString(),
+  accountId: accountId, // Public key owner
+  recipient: "your-service.near", // Can be a NEAR account ID or a URL/domain
 });
 
 // --- Send request with the token ---
@@ -30,95 +95,166 @@ fetch('https://api.example.com/endpoint', {
 });
 
 // --- Verify the token ---
-
-try {
-  const result = await verify(authToken, {
-    expectedRecipient: "your-service.near", // Ensure token is for your service
-    requireFullAccessKey: false,  // Allow Function Call Access Keys
-    nonceMaxAge: 300000,          // 5 minutes since message signed
-  });
-
-  // If verification is successful, you get a VerificationResult
-  console.log('Successfully verified for account:', result.accountId);
-  // you.near
-  console.log('Message from token:', result.message);
-  // { customInfo: 'login attempt' }
-
-} catch (error: any) {
-  // If verification fails, an error is thrown
-  console.error('Token verification failed:', error.message);
-}
-```
-
-## with fastintear
-
-Uses [fastintear](https://github.com/elliotBraem/fastintear), an expirmental fork of [@fastnear/js-monorepo](https://github.com/fastnear/js-monorepo) -- an alternative to [near-api-js](https://github.com/near/near-api-js) and [near-wallet-selector](https://github.com/near/wallet-selector).
-
-```typescript
-import * as near from "fastintear";
-import { sign, verify } from 'near-sign-verify';
-
-const authToken = await sign("login attempt", { // whatever message, can be validated on backend
-  signer: near, // has a signMessage function
-  recipient: 'app.near',
-});
-
-// --- Send request with the token ---
-
-fetch('https://api.example.com/endpoint', {
-  headers: { 'Authorization': `Bearer ${authToken}` },
-});
-
-// --- Verify the token ---
-
-try {
-  const result = await verify(authToken, {
-    expectedRecipient: "your-service.near", // Ensure token is for your service
-    // by default, wallet ensures a full access key (will always work)
-    nonceMaxAge: 300000,                    // 5 minutes since message signed
-  });
-
-  // If verification is successful, you get a VerificationResult
-  console.log('Successfully verified for account:', result.accountId);
-  // you.near
-  console.log('Message from token:', result.message);
-  // { customInfo: 'login attempt' }
-
-} catch (error: any) {
-  // If verification fails, an error is thrown
-  console.error('Token verification failed:', error.message);
-}
-```
-
-## with custom nonce + validation
-
-You can override the default nonce generation and validation (timestamp based, maxAge):
-
-```typescript
-import { sign, verify } from "near-sign-verify";
-
-const authToken = await sign("do something", { // whatever message, can be validated on backend
-  signer: wallet,
-  recipient: "your-service.near",
-  nonce: 1 // your nonce override
-})
 
 try {
   const result = await verify(authToken, {
     expectedRecipient: "your-service.near",
-    validateNonce: (nonce: Uint8Array): boolean => {
-      // do something
-      return true;
-    }
+    // requireFullAccessKey: true, // Default, but able to override at your own risk
+    nonceMaxAge: 300000,
   });
-  // optionally validate the message
-  const message = result.message;
-} catch {
-  // failed
+
+  console.log('Successfully verified for account:', result.accountId);
+  console.log('Message from token:', result.message);
+
+} catch (error: any) {
+  console.error('Token verification failed:', error.message);
 }
 ```
 
-## debugging
+### 3. Full Backend Integration (Recommended for Production)
+
+This strategy leverages your backend to manage nonces and states, providing the highest level of security against replay and CSRF attacks.
+
+**Flow:**
+
+1. **Client Request:** Frontend requests authentication parameters (message, nonce, state) from the backend.
+2. **Backend Generates:** Backend generates a unique nonce and state, stores them, and sends them to the frontend.
+3. **Client Signs:** Frontend uses these parameters to sign the message with the NEAR wallet.
+4. **Client Sends Signed Token:** Frontend sends the `authToken` back to the backend.
+5. **Backend Verifies:** Backend verifies the `authToken`, strictly validating the nonce and state against its stored values.
+
+```typescript
+// --- Client-side ---
+import { sign } from "near-sign-verify";
+
+onClick("Login with NEAR Button", async () => {
+  // Step 1 & 2: Client requests auth parameters from Backend
+  // Backend generates and stores state/nonce, then returns them.
+  const response = await fetch("https://your-service.com/api/auth/initiate-login");
+  const { state, message, nonce, recipient } = await response.json();
+
+  // Step 3: Client signs the message using the wallet (e.g., fastintear or similar)
+  const authToken = await sign(message, {
+    signer: wallet, // Your wallet object (e.g., from fastintear)
+    recipient: recipient, // From backend
+    nonce: new Uint8Array(nonce), // Nonce from backend (ensure it's Uint8Array)
+    state: state, // State from backend
+    // callbackUrl: callbackUrl, // Optional, if flow requires a backend redirect
+  });
+
+  // Step 4: Client sends the signed token to backend for verification
+  const verifyResponse = await fetch("https://your-service.com/api/auth/verify-login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ authToken }),
+  });
+
+  if (verifyResponse.ok) {
+    console.log("Authentication successful!");
+    // Redirect user or update UI
+  } else {
+    console.error("Authentication failed:", await verifyResponse.json());
+  }
+});
+
+// --- Server-side ---
+
+// Your database/store for temporary auth requests
+const authRequests = new Map(); // Use a real persistent store like Redis/DB in production
+const usedNonces = new Set<string>(); // example
+
+// Endpoint to initiate login flow
+POST("https://your-service.com/api/auth/initiate-login", (req, res) => {
+  const state = crypto.randomBytes(16).toString('hex'); // Generate secure random state
+  const nonce = crypto.randomBytes(32); // Generate secure random 32-byte nonce
+  const message = "Authorize my app";
+  const recipient = "your-service.com";
+
+  // Store the request details for later verification
+  authRequests.set(state, {
+    nonce: Array.from(nonce),
+    message: message,
+    recipient: recipient,
+    timestamp: Date.now() 
+  });
+
+  res.json({
+    state: state,
+    message: message, // The message the user will see and sign
+    nonce: Array.from(nonce), // Send as array for JSON
+    recipient: recipient
+  });
+});
+
+// Endpoint to verify signed token
+POST("https://your-service.com/api/auth/verify-request", async (req, res) => {
+  const { authToken } = req.body;
+
+  try {
+    const parsedData = parseAuthToken(authToken); // Helper to get nonce/state from token
+    const {
+      nonce: receivedNonce,
+      state: receivedState,
+      message: receivedMessage,
+      recipient: receivedRecipient
+    } = parsedData;
+
+    // Retrieve stored data using the received state as key
+    const storedAuthRequest = authRequests.get(receivedState);
+
+    // Step 3: Verify the token using custom validation functions
+    const result = await verify(authToken, {
+      expectedState: storedAuthRequest.state // Ensure state from token matches the one used to retrieve storedAuthRequest
+      validateNonce: (nonceFromToken: Uint8Array): boolean => {
+        const expectedNonceForState = new Uint8Array(storedAuthRequest.nonce);
+        
+        // Convert nonces to comparable strings (e.g., hex)
+        const receivedNonceHex = toHex(nonceFromToken);
+        const expectedNonceHex = toHex(expectedNonceForState);
+
+        // Does this nonce match the one we have stored for this state?
+        if (receivedNonceHex !== expectedNonceHex) {
+          console.error("Nonce mismatch: Received nonce does not match expected nonce for the state.");
+          return false;
+        }
+
+        // Has this nonce already been used?
+        if (usedNonces.has(receivedNonceHex)) {
+          console.error("Nonce already used (replay attack detected).");
+          return false;
+        }
+        
+        // If all checks pass for this nonce, mark as used
+        usedNonces.add(receivedNonceHex);
+        return true;
+      },
+      expectedMessage: storedAuthRequest.message, // Ensure message matches what was sent to client
+      // validateMessage: (message:string) => boolean // optionally, more complex message validation
+      validateRecipient: (recipientFromToken: string): boolean => {
+        // Example, recipient belongs to a list
+        const ALLOWED_LIST = ["your-service.com", "app.your-service.com", "your-service.near"];
+        return ALLOWED_LIST.includes(recipientFromToken);
+      }
+    });
+
+    // If verify is successful (all validations returned true and crypto verification passed):
+    // Clean up the used auth request to prevent reuse of the state/nonce
+    authRequests.delete(receivedState); 
+    res.json({ success: true, accountId: result.accountId, message: result.message });
+
+  } catch (e: any) {
+    // This catch block handles errors from `verify` itself (e.g., signature mismatch,
+    // or if a custom validator throws an error or returns false).
+    console.error("Token verification failed:", e.message);
+    // If state was involved, consider cleaning up authRequests entry if error is specific to it
+    if (receivedState && authRequests.has(receivedState)) {
+      authRequests.delete(receivedState);
+    }
+    res.status(400).json({ success: false, error: e.message });
+  }
+```
+
+## Debugging
 
 You can use the `parseAuthToken` helper method to inspect the outcome of `sign`.
 
@@ -126,5 +262,11 @@ You can use the `parseAuthToken` helper method to inspect the outcome of `sign`.
 
 import { parseAuthToken, type NearAuthData } from "near-sign-verify";
 
+const authHeader = c.req.header('Authorization');
+
+const authToken = authHeader.substring(7);
+
 const authData: NearAuthData = parseAuthToken(authToken);
+
+console.log("authData", authData);
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-sign-verify",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "description": "Creates and validates NEAR signatures for API authentication.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auth/sign.ts
+++ b/src/auth/sign.ts
@@ -132,16 +132,17 @@ function detectSignerType(
  * Signs a message using either a KeyPair or a wallet, creating a structured
  * message and producing a NEAR authentication token.
  *
+ * @param message The message to sign, can be application specific data.
  * @param options The signing options.
  * @returns A promise that resolves to the final AuthToken string.
  */
-export async function sign(options: SignOptions): Promise<string> {
-  const { signer, accountId, recipient, message, callbackUrl, nonce } = options;
+export async function sign(message: string, options: SignOptions): Promise<string> {
+  const { signer, accountId, recipient, callbackUrl, nonce } = options;
 
   const currentNonce = nonce || generateNonce();
 
   const internalParams: InternalSignParameters = {
-    message,
+    message: message,
     recipient: recipient,
     nonce: currentNonce,
     callbackUrl: callbackUrl,

--- a/src/auth/sign.ts
+++ b/src/auth/sign.ts
@@ -136,7 +136,10 @@ function detectSignerType(
  * @param options The signing options.
  * @returns A promise that resolves to the final AuthToken string.
  */
-export async function sign(message: string, options: SignOptions): Promise<string> {
+export async function sign(
+  message: string,
+  options: SignOptions,
+): Promise<string> {
   const { signer, accountId, recipient, callbackUrl, nonce } = options;
 
   const currentNonce = nonce || generateNonce();

--- a/src/auth/verify.ts
+++ b/src/auth/verify.ts
@@ -68,7 +68,7 @@ export async function verify(
     publicKey,
     signature: signatureB64,
     message: messageString,
-    nonce: nonceFromAuthData, // nonce from NearAuthPayload as number[]
+    nonce: nonceFromAuthData, // nonce from NearAuthData as number[]
     recipient: recipientFromAuthData,
     callbackUrl,
     state,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ export { verify } from "./auth/verify.js";
 
 // --- Helper Functions ---
 export { parseAuthToken } from "./auth/parseAuthToken.js";
-export { createAuthToken } from "./auth/createAuthToken.js";
 export { generateNonce, validateNonce } from "./utils/nonce.js";
 
 // --- Utility Exports ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ export { stringToUint8Array, uint8ArrayToString } from "./utils/encoding.js";
 // --- Core Types ---
 export type {
   NearAuthData,
-  NearAuthPayload,
   SignOptions,
   VerificationResult,
   VerifyOptions,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,14 +1,13 @@
 import { b } from "@zorsh/zorsh";
 
 /**
- * Zorsh schema for NearAuthPayload (what gets hashed and signed)
+ * Zorsh schema for SignedPayload (what gets hashed and signed)
  */
-export const NearAuthPayloadSchema = b.struct({
-  tag: b.u32(),
+export const SignedPayloadSchema = b.struct({
   message: b.string(),
-  nonce: b.array(b.u8(), 32),
-  receiver: b.string(),
-  callback_url: b.option(b.string()),
+  nonce: b.array(b.u8(), 32), // Represents [u8; 32]
+  recipient: b.string(),
+  callbackUrl: b.option(b.string()), // Optional field
 });
 
 /**
@@ -16,18 +15,18 @@ export const NearAuthPayloadSchema = b.struct({
  * Note: zorsh uses number[] for arrays, but our API uses Uint8Array
  */
 export const NearAuthDataSchema = b.struct({
-  account_id: b.string(),
-  public_key: b.string(),
+  accountId: b.string(),
+  publicKey: b.string(),
   signature: b.string(),
   message: b.string(),
   nonce: b.array(b.u8(), 32),
   recipient: b.string(),
-  callback_url: b.option(b.string()),
+  callbackUrl: b.option(b.string()),
   state: b.option(b.string()),
 });
 
 /**
  * TypeScript types inferred from zorsh schemas
  */
-export type NearAuthPayload = b.infer<typeof NearAuthPayloadSchema>;
+export type SignedPayload = b.infer<typeof SignedPayloadSchema>;
 export type NearAuthData = b.infer<typeof NearAuthDataSchema>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -23,6 +23,7 @@ export const NearAuthDataSchema = b.struct({
   nonce: b.array(b.u8(), 32),
   recipient: b.string(),
   callback_url: b.option(b.string()),
+  state: b.option(b.string()),
 });
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,17 +21,19 @@ export interface SignOptions {
    */
   recipient: string;
   /**
-   * Message to sign, can be application specific data.
-   */
-  message: string;
-  /**
    * Optional 32-byte nonce as a Uint8Array.
    * If not provided, a nonce will be generated.
    */
   nonce?: Uint8Array;
   /**
+   * Optional state object for authentication purposes, to be verified on backend.
+   * This is recommended to help mitigate CSRF attacks.
+   */
+  state?: string;
+  /**
    * Optional callback URL string.
-   * If provided, it will be included in the signed payload.
+   * If provided, this URL will receive a call after the signing process with the accountId, publicKey, signature, and state
+   * <callbackUrl>#accountId=<accountId>&publicKey=<publicKey>&signature=<signature>&state=<state>.
    */
   callbackUrl?: string | null;
 }
@@ -44,15 +46,12 @@ export type VerifyOptions = {
    * Whether the public key used for signing must be a Full Access Key.
    * Defaults to true. If false, Function Call Access Keys are permitted
    * provided they have permission for the `recipient`.
+   * 
+   * Full access is highly recommended, otherwise ensure message, nonce, and state validation are enforced.
    */
   requireFullAccessKey?: boolean;
-  /**
-   * If provided, the `recipient` field in the verified message
-   * must exactly match this string.
-   */
-  expectedRecipient?: string;
 } & (
-  | {
+    | {
       /**
        * Maximum age of the nonce in milliseconds.
        * If not provided, a default value (e.g., 24 hours) will be used.
@@ -61,7 +60,7 @@ export type VerifyOptions = {
       nonceMaxAge?: number;
       validateNonce?: never; // Ensures validateNonce is not provided with nonceMaxAge
     }
-  | {
+    | {
       /**
        * A custom function to validate the nonce.
        * Should return true if the nonce is valid, false otherwise.
@@ -70,7 +69,30 @@ export type VerifyOptions = {
       validateNonce: (nonce: Uint8Array) => boolean;
       nonceMaxAge?: never; // Ensures nonceMaxAge is not provided with validateNonce
     }
-);
+    & (
+      | {
+        /**
+         * The `recipient` field in the verified message must exactly match this string.
+         * If not provided, any recipient will be valid.
+         * This option is mutually exclusive with `validateRecipient`
+         */
+        expectedRecipient?: string;
+        validateRecipient?: never; // Ensures validateRecipient is not provided with expectedRecipient
+      }
+      | {
+        /**
+         * A custom function to validate the recipient.
+         * Should return false if the recipient is valid, false otherwise.
+         * This option is mutually exclusive with `expectedRecipient`;
+         */
+        validateRecipient?: (recipient: string) => boolean;
+        expectedRecipient?: never; // Ensures expectedRecipient is not provided with validateRecipient
+      }
+    )
+  );
+
+// expectedState?: string; // For simple state equality check.
+// validateState?: (state?: string) => boolean; // For custom state validation.
 
 /**
  * The result of a successful verification.
@@ -83,21 +105,60 @@ export interface VerificationResult {
   /** The public key string used for the signature. */
   publicKey: string;
   /** The callback URL from the token, if present. */
-  callbackUrl?: string | null;
+  callbackUrl?: string;
+  /** The state from the token, if present. */
+  state?: string;
 }
 
-/**
- * Defines the interface for a wallet signer.
- * This allows for duck-typing of wallet objects.
- */
+/** NEP-413: Parameters for the wallet's signMessage method. */
+export interface SignMessageParams {
+  message: string; // The message that wants to be transmitted (must be string for NEP-413 payload).
+  recipient: string; // The recipient to whom the message is destined.
+  nonce: Uint8Array; // A nonce that uniquely identifies this instance (32 bytes).
+  callbackUrl?: string; // Optional URL to call after signing.
+  state?: string; // Optional state for authentication purposes.
+}
+
+/** NEP-413: Output from the wallet's signMessage method. */
+export interface SignedMessage {
+  accountId: string; // The account name to which the publicKey corresponds as plain text (e.g. "alice.near")
+  publicKey: string; // Public key used for signing ("ed25519:<bs58>").
+  signature: string; // Base64 representation of the raw Ed25519 signature.
+  state?: string; // Optional state passed through, from SignMessageParams.
+}
+
+// Wallet Interface (works for fastnear or near-wallet-selector)
 export interface WalletInterface {
-  signMessage: (messageToSign: {
-    message: string;
-    recipient: string;
-    nonce: Uint8Array<ArrayBufferLike>;
-  }) => Promise<{
-    signature: string;
-    publicKey: string;
-    accountId: string;
-  }>;
+  /** Must conform to NEP-413 signMessage specification. */
+  signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
+}
+
+
+/** NEP-413: The structure whose Borsh representation (prepended with TAG) is hashed and signed. */
+export interface SignedPayload {
+  message: string; // Serialized version of the user's original message.
+  nonce: Uint8Array;
+  recipient: string;
+  callbackUrl?: string;
+}
+
+
+
+
+/** Data structure encoded within the library's authTokenString. */
+export interface NearAuthTokenPayload {
+  account_id: string;
+  public_key: string;
+  signature: string; // Base64 of raw signature
+
+  // Fields that were part of the signed SignedPayload
+  signed_message_content: string; // This is SignedPayload.message
+  signed_nonce: Uint8Array;       // This is SignedPayload.nonce
+  signed_recipient: string;     // This is SignedPayload.recipient
+  signed_callback_url?: string;  // This is SignedPayload.callbackUrl
+
+  // Additional metadata for the token (not part of the signature hash)
+  state?: string | null;
+  // To reconstruct the original TMessage if it was not a simple string.
+  original_message_representation?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export { NearAuthPayload, NearAuthData } from "./schemas.js";
+export { NearAuthData, SignedPayload } from "./schemas.js";
 /**
  * Options for the main `sign` function.
  */
@@ -181,12 +181,4 @@ export interface SignedMessage {
 export interface WalletInterface {
   /** Must conform to NEP-413 signMessage specification. */
   signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
-}
-
-/** NEP-413: The structure whose Borsh representation (prepended with TAG) is hashed and signed. */
-export interface SignedPayload {
-  message: string; // Serialized version of the user's original message.
-  nonce: Uint8Array;
-  recipient: string;
-  callbackUrl?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,68 +42,90 @@ export interface SignOptions {
  */
 type NonceValidationOptions =
   | {
-    /**
-     * Maximum age of the nonce in milliseconds.
-     * If not provided, a default value (e.g., 24 hours) will be used.
-     * This option is mutually exclusive with `validateNonce`.
-     */
-    nonceMaxAge?: number;
-    validateNonce?: never; // Ensures validateNonce is not provided with nonceMaxAge
-  }
+      /**
+       * Maximum age of the nonce in milliseconds.
+       * If not provided, a default value (e.g., 24 hours) will be used.
+       * This option is mutually exclusive with `validateNonce`.
+       */
+      nonceMaxAge?: number;
+      validateNonce?: never; // Ensures validateNonce is not provided with nonceMaxAge
+    }
   | {
-    /**
-     * A custom function to validate the nonce.
-     * Should return true if the nonce is valid, false otherwise.
-     * This option is mutually exclusive with `nonceMaxAge`.
-     */
-    validateNonce: (nonce: Uint8Array) => boolean;
-    nonceMaxAge?: never; // Ensures nonceMaxAge is not provided with validateNonce
-  };
+      /**
+       * A custom function to validate the nonce.
+       * Should return true if the nonce is valid, false otherwise.
+       * This option is mutually exclusive with `nonceMaxAge`.
+       */
+      validateNonce: (nonce: Uint8Array) => boolean;
+      nonceMaxAge?: never; // Ensures nonceMaxAge is not provided with validateNonce
+    };
 
 /**
  * Options for validating the recipient in the `verify` function.
  */
 type RecipientValidationOptions =
   | {
-    /**
-     * The `recipient` field in the verified message must exactly match this string.
-     * If not provided, any recipient will be valid.
-     * This option is mutually exclusive with `validateRecipient`.
-     */
-    expectedRecipient?: string;
-    validateRecipient?: never; // Ensures validateRecipient is not provided with expectedRecipient
-  }
+      /**
+       * The `recipient` field in the verified message must exactly match this string.
+       * If not provided, any recipient will be valid.
+       * This option is mutually exclusive with `validateRecipient`.
+       */
+      expectedRecipient?: string;
+      validateRecipient?: never; // Ensures validateRecipient is not provided with expectedRecipient
+    }
   | {
-    /**
-     * A custom function to validate the recipient.
-     * Should return true if the recipient is valid, false otherwise.
-     * This option is mutually exclusive with `expectedRecipient`.
-     */
-    validateRecipient: (recipient: string) => boolean;
-    expectedRecipient?: never; // Ensures expectedRecipient is not provided with validateRecipient
-  };
+      /**
+       * A custom function to validate the recipient.
+       * Should return true if the recipient is valid, false otherwise.
+       * This option is mutually exclusive with `expectedRecipient`.
+       */
+      validateRecipient: (recipient: string) => boolean;
+      expectedRecipient?: never; // Ensures expectedRecipient is not provided with validateRecipient
+    };
 
 /**
  * Options for validating the state in the `verify` function.
  */
 type StateValidationOptions =
   | {
-    /**
-     * The `state` field in the verified message must exactly match this string.
-     * This option is mutually exclusive with `validateState`.
-     */
-    expectedState?: string;
-    validateState?: never; // Ensures validateState is not provided with expectedState
-  }
+      /**
+       * The `state` field in the verified message must exactly match this string.
+       * This option is mutually exclusive with `validateState`.
+       */
+      expectedState?: string;
+      validateState?: never; // Ensures validateState is not provided with expectedState
+    }
   | {
-    /**
-     * A custom function to validate the state.
-     * Should return true if the state is valid, false otherwise.
-     * This option is mutually exclusive with `expectedState`.
-     */
-    validateState: (state?: string) => boolean;
-    expectedState?: never; // Ensures expectedState is not provided with validateState
-  };
+      /**
+       * A custom function to validate the state.
+       * Should return true if the state is valid, false otherwise.
+       * This option is mutually exclusive with `expectedState`.
+       */
+      validateState: (state?: string) => boolean;
+      expectedState?: never; // Ensures expectedState is not provided with validateState
+    };
+
+/**
+ * Options for validating the message in the `verify` function.
+ */
+type MessageValidationOptions =
+  | {
+      /**
+       * The `message` field in the verified token must exactly match this string.
+       * This option is mutually exclusive with `validateMessage`.
+       */
+      expectedMessage?: string;
+      validateMessage?: never; // Ensures validateMessage is not provided with expectedMessage
+    }
+  | {
+      /**
+       * A custom function to validate the message.
+       * Should return true if the message is valid, false otherwise.
+       * This option is mutually exclusive with `expectedMessage`.
+       */
+      validateMessage: (message: string) => boolean;
+      expectedMessage?: never; // Ensures expectedMessage is not provided with validateMessage
+    };
 
 /**
  * Options for the main `verify` function.
@@ -119,7 +141,8 @@ export type VerifyOptions = {
   requireFullAccessKey?: boolean;
 } & NonceValidationOptions &
   RecipientValidationOptions &
-  StateValidationOptions;
+  StateValidationOptions &
+  MessageValidationOptions;
 
 /**
  * The result of a successful verification.
@@ -159,7 +182,6 @@ export interface WalletInterface {
   /** Must conform to NEP-413 signMessage specification. */
   signMessage: (params: SignMessageParams) => Promise<SignedMessage>;
 }
-
 
 /** NEP-413: The structure whose Borsh representation (prepended with TAG) is hashed and signed. */
 export interface SignedPayload {

--- a/tests/auth/createAuthToken.test.ts
+++ b/tests/auth/createAuthToken.test.ts
@@ -6,13 +6,13 @@ import type { NearAuthData } from "../../src/schemas.js";
 describe("createAuthToken", () => {
   it("should create a properly formatted auth token that can be parsed back", () => {
     const authData: NearAuthData = {
-      account_id: "test.near",
-      public_key: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
+      accountId: "test.near",
+      publicKey: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
       signature: "base64signature",
       message: "Hello, world!",
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
-      callback_url: null,
+      callbackUrl: null,
     };
 
     const token = createAuthToken(authData);
@@ -24,29 +24,29 @@ describe("createAuthToken", () => {
     const parsed = parseAuthToken(token);
 
     // Compare essential fields (ignoring null optional fields)
-    expect(parsed.account_id).toEqual(authData.account_id);
-    expect(parsed.public_key).toEqual(authData.public_key);
+    expect(parsed.accountId).toEqual(authData.accountId);
+    expect(parsed.publicKey).toEqual(authData.publicKey);
     expect(parsed.signature).toEqual(authData.signature);
     expect(parsed.message).toEqual(authData.message);
     expect(parsed.nonce).toEqual(authData.nonce);
     expect(parsed.recipient).toEqual(authData.recipient);
   });
 
-  it("should include callback_url when provided", () => {
+  it("should include callbackUrl when provided", () => {
     const authData: NearAuthData = {
-      account_id: "test.near",
-      public_key: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
+      accountId: "test.near",
+      publicKey: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
       signature: "base64signature",
       message: "Hello, world!",
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
-      callback_url: "https://example.com/callback",
+      callbackUrl: "https://example.com/callback",
     };
 
     const token = createAuthToken(authData);
 
-    // Should be able to parse it back with callback_url
+    // Should be able to parse it back with callbackUrl
     const parsed = parseAuthToken(token);
-    expect(parsed.callback_url).toBe("https://example.com/callback");
+    expect(parsed.callbackUrl).toBe("https://example.com/callback");
   });
 });

--- a/tests/auth/parseAuthToken.test.ts
+++ b/tests/auth/parseAuthToken.test.ts
@@ -13,6 +13,7 @@ describe("parseAuthToken", () => {
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
       callback_url: "https://example.com/callback",
+      state: null
     };
 
     const token = createAuthToken(authData);
@@ -46,12 +47,13 @@ describe("parseAuthToken", () => {
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
       callback_url: null,
+      state: null
     };
 
     const token = createAuthToken(authData);
 
     // Corrupt the token by replacing some characters
-    const corruptedToken = token.substring(0, token.length - 5) + "XXXXX";
+    const corruptedToken = token.substring(0, token.length - 10) + "XXXXXXXXXX";
 
     // Zorsh may successfully parse corrupted data but with garbled fields
     const parsed = parseAuthToken(corruptedToken);

--- a/tests/auth/parseAuthToken.test.ts
+++ b/tests/auth/parseAuthToken.test.ts
@@ -13,7 +13,7 @@ describe("parseAuthToken", () => {
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
       callback_url: "https://example.com/callback",
-      state: null
+      state: null,
     };
 
     const token = createAuthToken(authData);
@@ -47,7 +47,7 @@ describe("parseAuthToken", () => {
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
       callback_url: null,
-      state: null
+      state: null,
     };
 
     const token = createAuthToken(authData);

--- a/tests/auth/parseAuthToken.test.ts
+++ b/tests/auth/parseAuthToken.test.ts
@@ -6,27 +6,27 @@ import type { NearAuthData } from "../../src/schemas.js";
 describe("parseAuthToken", () => {
   it("should handle optional fields", () => {
     const authData: NearAuthData = {
-      account_id: "test.near",
-      public_key: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
+      accountId: "test.near",
+      publicKey: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
       signature: "base64signature",
       message: "Hello, world!",
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
-      callback_url: "https://example.com/callback",
+      callbackUrl: "https://example.com/callback",
       state: null,
     };
 
     const token = createAuthToken(authData);
     const parsed = parseAuthToken(token);
 
-    expect(parsed.account_id).toEqual(authData.account_id);
-    expect(parsed.public_key).toEqual(authData.public_key);
+    expect(parsed.accountId).toEqual(authData.accountId);
+    expect(parsed.publicKey).toEqual(authData.publicKey);
     expect(parsed.signature).toEqual(authData.signature);
     expect(parsed.message).toEqual(authData.message);
     expect(parsed.nonce).toEqual(authData.nonce);
     expect(parsed.recipient).toEqual(authData.recipient);
-    expect(parsed.callback_url).toEqual(authData.callback_url);
-    expect(parsed.callback_url).toBe("https://example.com/callback");
+    expect(parsed.callbackUrl).toEqual(authData.callbackUrl);
+    expect(parsed.callbackUrl).toBe("https://example.com/callback");
   });
 
   it("should throw an error for invalid token format", () => {
@@ -40,13 +40,13 @@ describe("parseAuthToken", () => {
   it("should handle corrupted token data gracefully", () => {
     // Create a valid token first
     const authData: NearAuthData = {
-      account_id: "test.near",
-      public_key: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
+      accountId: "test.near",
+      publicKey: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
       signature: "base64signature",
       message: "Hello, world!",
       nonce: Array(32).fill(0),
       recipient: "recipient.near",
-      callback_url: null,
+      callbackUrl: null,
       state: null,
     };
 
@@ -58,8 +58,8 @@ describe("parseAuthToken", () => {
     // Zorsh may successfully parse corrupted data but with garbled fields
     const parsed = parseAuthToken(corruptedToken);
 
-    // The account_id should be preserved (it comes early in the serialization)
-    expect(parsed.account_id).toBe("test.near");
+    // The accountId should be preserved (it comes early in the serialization)
+    expect(parsed.accountId).toBe("test.near");
 
     // But the recipient field (which comes later) should be corrupted
     expect(parsed.recipient).not.toBe("recipient.near");

--- a/tests/auth/sign-edge-cases.test.ts
+++ b/tests/auth/sign-edge-cases.test.ts
@@ -19,7 +19,7 @@ describe("sign - Edge Cases", () => {
   it("should throw error for invalid signer type", async () => {
     const invalidSigner = {
       // Missing both KeyPair methods and WalletInterface methods
-      someOtherMethod: () => { },
+      someOtherMethod: () => {},
     } as any;
 
     await expect(
@@ -35,7 +35,7 @@ describe("sign - Edge Cases", () => {
 
   it("should throw error for object with only partial KeyPair interface", async () => {
     const partialKeyPair = {
-      sign: () => { }, // Has sign but missing getPublicKey
+      sign: () => {}, // Has sign but missing getPublicKey
     } as any;
 
     await expect(
@@ -51,7 +51,7 @@ describe("sign - Edge Cases", () => {
 
   it("should throw error for object with only partial WalletInterface", async () => {
     const partialWallet = {
-      someMethod: () => { }, // Missing signMessage
+      someMethod: () => {}, // Missing signMessage
     } as any;
 
     await expect(

--- a/tests/auth/sign-edge-cases.test.ts
+++ b/tests/auth/sign-edge-cases.test.ts
@@ -9,9 +9,8 @@ describe("sign - Edge Cases", () => {
     const keyPair = near.KeyPair.fromRandom("ed25519");
 
     await expect(
-      sign({
+      sign("hello", {
         signer: keyPair.toString(),
-        message: "hello",
         recipient: "recipient.near",
       }),
     ).rejects.toThrow("accountId is required when using a KeyPair signer");
@@ -20,14 +19,13 @@ describe("sign - Edge Cases", () => {
   it("should throw error for invalid signer type", async () => {
     const invalidSigner = {
       // Missing both KeyPair methods and WalletInterface methods
-      someOtherMethod: () => {},
+      someOtherMethod: () => { },
     } as any;
 
     await expect(
-      sign({
+      sign("hello", {
         signer: invalidSigner,
         accountId: "test.near",
-        message: "hello",
         recipient: "recipient.near",
       }),
     ).rejects.toThrow(
@@ -37,14 +35,13 @@ describe("sign - Edge Cases", () => {
 
   it("should throw error for object with only partial KeyPair interface", async () => {
     const partialKeyPair = {
-      sign: () => {}, // Has sign but missing getPublicKey
+      sign: () => { }, // Has sign but missing getPublicKey
     } as any;
 
     await expect(
-      sign({
+      sign("hello", {
         signer: partialKeyPair,
         accountId: "test.near",
-        message: "hello",
         recipient: "recipient.near",
       }),
     ).rejects.toThrow(
@@ -54,14 +51,13 @@ describe("sign - Edge Cases", () => {
 
   it("should throw error for object with only partial WalletInterface", async () => {
     const partialWallet = {
-      someMethod: () => {}, // Missing signMessage
+      someMethod: () => { }, // Missing signMessage
     } as any;
 
     await expect(
-      sign({
+      sign("hello", {
         signer: partialWallet,
         accountId: "test.near",
-        message: "hello",
         recipient: "recipient.near",
       }),
     ).rejects.toThrow(
@@ -77,10 +73,9 @@ describe("sign - Edge Cases", () => {
     };
 
     await expect(
-      sign({
+      sign("hello", {
         signer: mockWallet,
         recipient: "recipient.near",
-        message: "hello",
       }),
     ).rejects.toThrow("Wallet signing failed");
   });
@@ -89,10 +84,9 @@ describe("sign - Edge Cases", () => {
     const malformedKeyPairString =
       "ed25519:ThisIsNotValidBase58AndWillCauseAnErrorDuringDecoding!!!";
     await expect(
-      sign({
+      sign("hello", {
         signer: malformedKeyPairString,
         accountId: "test.near",
-        message: "hello",
         recipient: "recipient.near",
       }),
     ).rejects.toThrow(
@@ -111,9 +105,8 @@ describe("sign - Edge Cases", () => {
       }),
     };
 
-    const result = await sign({
+    const result = await sign("hello", {
       signer: mockWallet,
-      message: "hello",
       recipient: "recipient.near",
     });
 

--- a/tests/auth/sign.test.ts
+++ b/tests/auth/sign.test.ts
@@ -46,12 +46,11 @@ describe("Sign Function", () => {
       signer: FCAK_KEY_PAIR.toString(),
       accountId: ACCOUNT_ID,
       recipient,
-      message: JSON.stringify(appData),
       callbackUrl,
       nonce: specificNonce,
     };
 
-    const authTokenString: string = await sign(signOptions);
+    const authTokenString: string = await sign(JSON.stringify(appData), signOptions);
     expect(authTokenString).toBeDefined();
     expect(typeof authTokenString).toBe("string");
 
@@ -88,11 +87,10 @@ describe("Sign Function", () => {
       signer: FCAK_KEY_PAIR.toString(),
       accountId: ACCOUNT_ID,
       recipient,
-      message: "Another test message",
       // No nonce provided
     };
 
-    const authTokenString: string = await sign(signOptions);
+    const authTokenString: string = await sign("Another test message", signOptions);
     expect(authTokenString).toBeDefined();
 
     const verificationResult: VerificationResult = await verify(

--- a/tests/auth/sign.test.ts
+++ b/tests/auth/sign.test.ts
@@ -50,7 +50,10 @@ describe("Sign Function", () => {
       nonce: specificNonce,
     };
 
-    const authTokenString: string = await sign(JSON.stringify(appData), signOptions);
+    const authTokenString: string = await sign(
+      JSON.stringify(appData),
+      signOptions,
+    );
     expect(authTokenString).toBeDefined();
     expect(typeof authTokenString).toBe("string");
 
@@ -90,7 +93,10 @@ describe("Sign Function", () => {
       // No nonce provided
     };
 
-    const authTokenString: string = await sign("Another test message", signOptions);
+    const authTokenString: string = await sign(
+      "Another test message",
+      signOptions,
+    );
     expect(authTokenString).toBeDefined();
 
     const verificationResult: VerificationResult = await verify(

--- a/tests/auth/sign.test.ts
+++ b/tests/auth/sign.test.ts
@@ -13,8 +13,8 @@ import {
 
 dotenv.config();
 
-const ACCOUNT_ID = "signverifytests.testnet";
-const FCAK_PUBLIC_KEY_STR =
+const accountId = "signverifytests.testnet";
+const FCAK_publicKey_STR =
   "ed25519:DKFEx1W5rxMNVAnqJ25Cq47Xvys4zZsrJg8bzgT971vt";
 let FCAK_KEY_PAIR: near.KeyPair;
 
@@ -29,9 +29,9 @@ describe("Sign Function", () => {
     FCAK_KEY_PAIR = near.KeyPair.fromString(
       fcakSecretKey as near.utils.KeyPairString,
     );
-    if (FCAK_KEY_PAIR.getPublicKey().toString() !== FCAK_PUBLIC_KEY_STR) {
+    if (FCAK_KEY_PAIR.getPublicKey().toString() !== FCAK_publicKey_STR) {
       throw new Error(
-        "Provided FCAK_SECRET_KEY does not match FCAK_PUBLIC_KEY_STR.",
+        "Provided FCAK_SECRET_KEY does not match FCAK_publicKey_STR.",
       );
     }
   });
@@ -44,7 +44,7 @@ describe("Sign Function", () => {
 
     const signOptions: SignOptions = {
       signer: FCAK_KEY_PAIR.toString(),
-      accountId: ACCOUNT_ID,
+      accountId: accountId,
       recipient,
       callbackUrl,
       nonce: specificNonce,
@@ -67,17 +67,17 @@ describe("Sign Function", () => {
     );
 
     expect(verificationResult).toBeDefined();
-    expect(verificationResult.accountId).toBe(ACCOUNT_ID);
-    expect(verificationResult.publicKey).toBe(FCAK_PUBLIC_KEY_STR);
+    expect(verificationResult.accountId).toBe(accountId);
+    expect(verificationResult.publicKey).toBe(FCAK_publicKey_STR);
     expect(verificationResult.callbackUrl).toBe(callbackUrl);
     expect(verificationResult.message).toEqual(JSON.stringify(appData));
 
     // Optionally, parse the token directly to check raw NearAuthData
     const parsedNearAuthData: NearAuthData = parseAuthToken(authTokenString);
-    expect(parsedNearAuthData.account_id).toBe(ACCOUNT_ID);
-    expect(parsedNearAuthData.public_key).toBe(FCAK_PUBLIC_KEY_STR);
+    expect(parsedNearAuthData.accountId).toBe(accountId);
+    expect(parsedNearAuthData.publicKey).toBe(FCAK_publicKey_STR);
     expect(parsedNearAuthData.recipient).toBe(recipient);
-    expect(parsedNearAuthData.callback_url).toBe(callbackUrl);
+    expect(parsedNearAuthData.callbackUrl).toBe(callbackUrl);
     expect(new Uint8Array(parsedNearAuthData.nonce)).toStrictEqual(
       specificNonce,
     );
@@ -88,7 +88,7 @@ describe("Sign Function", () => {
 
     const signOptions: SignOptions = {
       signer: FCAK_KEY_PAIR.toString(),
-      accountId: ACCOUNT_ID,
+      accountId: accountId,
       recipient,
       // No nonce provided
     };
@@ -108,7 +108,7 @@ describe("Sign Function", () => {
     );
 
     expect(verificationResult).toBeDefined();
-    expect(verificationResult.accountId).toBe(ACCOUNT_ID);
+    expect(verificationResult.accountId).toBe(accountId);
 
     // Check raw parsed data
     const parsedNearAuthData: NearAuthData = parseAuthToken(authTokenString);

--- a/tests/auth/verify-edge-cases.test.ts
+++ b/tests/auth/verify-edge-cases.test.ts
@@ -16,14 +16,14 @@ describe("verify - Edge Cases", () => {
   const testNonce = new Uint8Array(32);
 
   const baseAuthData: NearAuthData = {
-    account_id: "testuser.testnet",
-    public_key: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
+    accountId: "testuser.testnet",
+    publicKey: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
     signature:
       "YN7xw5bhbD2VzrOlyyGwKKEaCBsuCVO9vu1AY1GkqQRRfOL2JNTjUUxJXp9KfC2nmA2xvytDdUzel0vmr/VDuA==",
     message: "test message",
     nonce: Array.from(testNonce),
     recipient: "recipient.near",
-    callback_url: null,
+    callbackUrl: null,
     state: "edge-case-state",
   };
 
@@ -46,7 +46,7 @@ describe("verify - Edge Cases", () => {
   it("should handle FastNEAR API returning unexpected response format", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ unexpected: "format" }), // Missing account_ids array
+      json: async () => ({ unexpected: "format" }), // Missing accountIds array
     });
 
     const tokenString = createAuthToken(baseAuthData);
@@ -97,7 +97,7 @@ describe("verify - Edge Cases", () => {
 
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
@@ -133,7 +133,7 @@ describe("verify - Edge Cases", () => {
 
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
@@ -145,7 +145,7 @@ describe("verify - Edge Cases", () => {
     const specialAccountId = "test-user_123.testnet";
     const specialAuthData: NearAuthData = {
       ...baseAuthData,
-      account_id: specialAccountId,
+      accountId: specialAccountId,
     };
 
     const tokenString = createAuthToken(specialAuthData);
@@ -214,7 +214,7 @@ describe("verify - Edge Cases", () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        account_ids: [authDataWithoutStateProperty.account_id],
+        account_ids: [authDataWithoutStateProperty.accountId],
       }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
@@ -233,7 +233,7 @@ describe("verify - Edge Cases", () => {
     const tokenString = createAuthToken(authDataUndefinedState);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [authDataUndefinedState.account_id] }),
+      json: async () => ({ account_ids: [authDataUndefinedState.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
@@ -262,7 +262,7 @@ describe("verify - Edge Cases", () => {
     const tokenString = createAuthToken(authDataEmptyMessage);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [authDataEmptyMessage.account_id] }),
+      json: async () => ({ account_ids: [authDataEmptyMessage.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
@@ -288,7 +288,7 @@ describe("verify - Edge Cases", () => {
     const customValidateMessage = vi.fn().mockReturnValue(true);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [authDataEmptyMessage.account_id] }),
+      json: async () => ({ account_ids: [authDataEmptyMessage.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 

--- a/tests/auth/verify.test.ts
+++ b/tests/auth/verify.test.ts
@@ -16,14 +16,14 @@ describe("verify", () => {
   const testNonce = new Uint8Array(32); // Assuming a valid 32-byte nonce
 
   const baseAuthData: NearAuthData = {
-    account_id: "testuser.testnet",
-    public_key: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
+    accountId: "testuser.testnet",
+    publicKey: "ed25519:8hSHprDq2StXwMtNd43wDTXQYsjXcD4MJxUTvwtnmM4T",
     signature:
       "YN7xw5bhbD2VzrOlyyGwKKEaCBsuCVO9vu1AY1GkqQRRfOL2JNTjUUxJXp9KfC2nmA2xvytDdUzel0vmr/VDuA==",
     message: "test message",
     nonce: Array.from(testNonce),
     recipient: "recipient.near",
-    callback_url: null,
+    callbackUrl: null,
     state: "test-state-123",
   };
 
@@ -44,21 +44,21 @@ describe("verify", () => {
   it("should validate a signature with valid nonce, ownership, and crypto signature", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(authTokenString);
 
-    expect(result.accountId).toBe(baseAuthData.account_id);
-    expect(result.publicKey).toBe(baseAuthData.public_key);
+    expect(result.accountId).toBe(baseAuthData.accountId);
+    expect(result.publicKey).toBe(baseAuthData.publicKey);
     expect(result.message).toEqual("test message");
     expect(nonceModule.validateNonce).toHaveBeenCalledWith(
       new Uint8Array(baseAuthData.nonce),
       undefined,
     ); // No nonceMaxAge passed
     expect(fetch).toHaveBeenCalledWith(
-      `https://test.api.fastnear.com/v0/public_key/${baseAuthData.public_key}`, // Default requireFullAccessKey=true
+      `https://test.api.fastnear.com/v0/public_key/${baseAuthData.publicKey}`, // Default requireFullAccessKey=true
     );
     expect(cryptoModule.verifySignature).toHaveBeenCalled();
   });
@@ -66,7 +66,7 @@ describe("verify", () => {
   it("should reject if public key does not belong to the account", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: ["anotheruser.testnet"] }), // account_id not in list
+      json: async () => ({ account_ids: ["anotheruser.testnet"] }), // accountId not in list
     });
 
     await expect(verify(authTokenString)).rejects.toThrow(
@@ -102,7 +102,7 @@ describe("verify", () => {
   it("should use /all endpoint and succeed if requireFullAccessKey is false", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
@@ -110,16 +110,16 @@ describe("verify", () => {
       requireFullAccessKey: false,
     });
 
-    expect(result.accountId).toBe(baseAuthData.account_id);
+    expect(result.accountId).toBe(baseAuthData.accountId);
     expect(fetch).toHaveBeenCalledWith(
-      `https://test.api.fastnear.com/v0/public_key/${baseAuthData.public_key}/all`,
+      `https://test.api.fastnear.com/v0/public_key/${baseAuthData.publicKey}/all`,
     );
   });
 
   it("should use mainnet FastNEAR API for mainnet accounts", async () => {
     const mainnetAuthData: NearAuthData = {
       ...baseAuthData,
-      account_id: "user.near",
+      accountId: "user.near",
       message: "test message",
       recipient: "mainnet-recipient.near",
     };
@@ -127,22 +127,22 @@ describe("verify", () => {
 
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [mainnetAuthData.account_id] }),
+      json: async () => ({ account_ids: [mainnetAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(mainnetTokenString);
 
-    expect(result.accountId).toBe(mainnetAuthData.account_id);
+    expect(result.accountId).toBe(mainnetAuthData.accountId);
     expect(fetch).toHaveBeenCalledWith(
-      `https://api.fastnear.com/v0/public_key/${mainnetAuthData.public_key}`,
+      `https://api.fastnear.com/v0/public_key/${mainnetAuthData.publicKey}`,
     );
   });
 
   it("should reject an invalid cryptographic signature after successful ownership check", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     // Simulate crypto.verifySignature throwing an error for an invalid signature
     vi.spyOn(cryptoModule, "verifySignature").mockRejectedValue(
@@ -167,7 +167,7 @@ describe("verify", () => {
   it("should handle exceptions during cryptographic signature validation", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockRejectedValue(
       new Error("Crypto error"),
@@ -180,13 +180,13 @@ describe("verify", () => {
     const nonceMaxAge = 5 * 60 * 1000; // 5 minutes
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(authTokenString, { nonceMaxAge });
 
-    expect(result.accountId).toBe(baseAuthData.account_id);
+    expect(result.accountId).toBe(baseAuthData.accountId);
     expect(nonceModule.validateNonce).toHaveBeenCalledWith(
       new Uint8Array(baseAuthData.nonce),
       nonceMaxAge,
@@ -196,7 +196,7 @@ describe("verify", () => {
   it("should handle unexpected error during public key decoding", async () => {
     const faultyAuthData: NearAuthData = {
       ...baseAuthData,
-      public_key: "ed25519:InvalidKeyChars$$", // Invalid base58 characters
+      publicKey: "ed25519:InvalidKeyChars$$", // Invalid base58 characters
       message: JSON.stringify("faultyMessageData"),
     };
     const faultyTokenString = createAuthToken(faultyAuthData);
@@ -204,13 +204,13 @@ describe("verify", () => {
     // Mock fetch to make verifyPublicKeyOwner pass, so we can test PublicKey.fromString failure
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [faultyAuthData.account_id] }),
+      json: async () => ({ account_ids: [faultyAuthData.accountId] }),
     });
 
     // The error should come from crypto.verifySignature when PublicKey.fromString fails.
     vi.spyOn(cryptoModule, "verifySignature").mockImplementation(
       async (hash, sig, pkString) => {
-        if (pkString === faultyAuthData.public_key) {
+        if (pkString === faultyAuthData.publicKey) {
           // Use the actual faulty public key
           // Simulate PublicKey.fromString throwing an error due to invalid characters
           throw new Error(
@@ -259,7 +259,7 @@ describe("verify", () => {
   it("should validate expectedRecipient option", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
 
     await expect(
@@ -276,14 +276,14 @@ describe("verify", () => {
   it("should validate with matching expectedState", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(authTokenString, {
       expectedState: "test-state-123",
     });
-    expect(result.accountId).toBe(baseAuthData.account_id);
+    expect(result.accountId).toBe(baseAuthData.accountId);
     expect(result.state).toBe("test-state-123");
   });
 
@@ -316,14 +316,14 @@ describe("verify", () => {
     const customValidateState = vi.fn().mockReturnValue(true);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(authTokenString, {
       validateState: customValidateState,
     });
-    expect(result.accountId).toBe(baseAuthData.account_id);
+    expect(result.accountId).toBe(baseAuthData.accountId);
     expect(customValidateState).toHaveBeenCalledWith("test-state-123");
   });
 
@@ -341,14 +341,14 @@ describe("verify", () => {
   it("should validate with matching expectedMessage", async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(authTokenString, {
       expectedMessage: "test message",
     });
-    expect(result.accountId).toBe(baseAuthData.account_id);
+    expect(result.accountId).toBe(baseAuthData.accountId);
     expect(result.message).toBe("test message");
   });
 
@@ -367,14 +367,14 @@ describe("verify", () => {
     const customValidateMessage = vi.fn().mockReturnValue(true);
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ account_ids: [baseAuthData.account_id] }),
+      json: async () => ({ account_ids: [baseAuthData.accountId] }),
     });
     vi.spyOn(cryptoModule, "verifySignature").mockResolvedValue(true);
 
     const result = await verify(authTokenString, {
       validateMessage: customValidateMessage,
     });
-    expect(result.accountId).toBe(baseAuthData.account_id);
+    expect(result.accountId).toBe(baseAuthData.accountId);
     expect(customValidateMessage).toHaveBeenCalledWith("test message");
   });
 

--- a/tests/crypto/crypto-edge-cases.test.ts
+++ b/tests/crypto/crypto-edge-cases.test.ts
@@ -1,12 +1,12 @@
 import * as near from "near-api-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createNEP413Payload,
   ED25519_PREFIX,
   hashPayload,
-  serializePayload,
   verifySignature,
 } from "../../src/crypto/crypto.js";
-import type { NearAuthPayload } from "../../src/types.js";
+import { SignedPayload } from "../../src/schemas.js";
 
 describe("Crypto Module - Edge Cases & Core Functionality", () => {
   afterEach(() => {
@@ -91,28 +91,26 @@ describe("Crypto Module - Edge Cases & Core Functionality", () => {
 
   describe("serializePayload", () => {
     it("should serialize payload with all optional fields", () => {
-      const payload: NearAuthPayload = {
-        tag: 2147484061,
+      const payload: SignedPayload = {
         message: "test message",
         nonce: new Array(32).fill(1),
-        receiver: "test.near",
-        callback_url: "https://example.com/callback",
+        recipient: "test.near",
+        callbackUrl: "https://example.com/callback",
       };
-      const serialized = serializePayload(payload);
+      const serialized = createNEP413Payload(payload);
       expect(serialized).toBeInstanceOf(Uint8Array);
       expect(serialized.length).toBeGreaterThan(0);
     });
 
-    it("should serialize payload without optional callback_url", () => {
+    it("should serialize payload without optional callbackUrl", () => {
       // @ts-expect-error we're specifically testing a missing field
-      const payload: NearAuthPayload = {
-        tag: 2147484061,
+      const payload: SignedPayload = {
         message: "test message",
         nonce: new Array(32).fill(1),
-        receiver: "test.near",
-        // callback_url is undefined
+        recipient: "test.near",
+        // callbackUrl is undefined
       };
-      const serialized = serializePayload(payload);
+      const serialized = createNEP413Payload(payload);
       expect(serialized).toBeInstanceOf(Uint8Array);
       expect(serialized.length).toBeGreaterThan(0);
     });

--- a/tests/integration/signature-flow.test.ts
+++ b/tests/integration/signature-flow.test.ts
@@ -110,7 +110,10 @@ describe("NEAR Signature Flow Integration Test", () => {
       recipient,
       nonce: specificNonce,
     };
-    const authTokenString = await sign("Test with FCAK, requireFullAccessKey=true", signOptions);
+    const authTokenString = await sign(
+      "Test with FCAK, requireFullAccessKey=true",
+      signOptions,
+    );
 
     const verifyOpts: VerifyOptions = {
       requireFullAccessKey: true,
@@ -131,7 +134,10 @@ describe("NEAR Signature Flow Integration Test", () => {
       recipient,
       nonce: specificNonce,
     };
-    const authTokenString = await sign("Test with FCAK, requireFullAccessKey=false", signOptions);
+    const authTokenString = await sign(
+      "Test with FCAK, requireFullAccessKey=false",
+      signOptions,
+    );
 
     const verifyOpts: VerifyOptions = {
       requireFullAccessKey: false,
@@ -157,7 +163,10 @@ describe("NEAR Signature Flow Integration Test", () => {
       recipient,
       nonce: specificNonce,
     };
-    const authTokenString = await sign("Test with random unassociated PK", signOptions);
+    const authTokenString = await sign(
+      "Test with random unassociated PK",
+      signOptions,
+    );
 
     await expect(
       verify(authTokenString, { expectedRecipient: recipient }),

--- a/tests/integration/signature-flow.test.ts
+++ b/tests/integration/signature-flow.test.ts
@@ -64,12 +64,11 @@ describe("NEAR Signature Flow Integration Test", () => {
       signer: wrongKeyPair.toString(), // Signing with this wrong key
       accountId: intendedAccountId, // But claiming this account ID
       recipient,
-      message: "Test wrong key",
       nonce: specificNonce,
       callbackUrl,
     };
 
-    const authTokenString = await sign(signOptions);
+    const authTokenString = await sign("Test wrong key", signOptions);
 
     await expect(
       verify(authTokenString, { expectedRecipient: recipient }),
@@ -85,11 +84,10 @@ describe("NEAR Signature Flow Integration Test", () => {
       signer: FAK_KEY_PAIR.toString(),
       accountId: SIGNVERIFYTESTS_ACCOUNT_ID,
       recipient,
-      message: "Test with FAK",
       nonce: specificNonce,
       callbackUrl,
     };
-    const authTokenString = await sign(signOptions);
+    const authTokenString = await sign("Test with FAK", signOptions);
 
     const verificationResult: VerificationResult = await verify(
       authTokenString,
@@ -110,10 +108,9 @@ describe("NEAR Signature Flow Integration Test", () => {
       signer: FCAK_KEY_PAIR.toString(),
       accountId: SIGNVERIFYTESTS_ACCOUNT_ID,
       recipient,
-      message: "Test with FCAK, requireFullAccessKey=true",
       nonce: specificNonce,
     };
-    const authTokenString = await sign(signOptions);
+    const authTokenString = await sign("Test with FCAK, requireFullAccessKey=true", signOptions);
 
     const verifyOpts: VerifyOptions = {
       requireFullAccessKey: true,
@@ -132,10 +129,9 @@ describe("NEAR Signature Flow Integration Test", () => {
       signer: FCAK_KEY_PAIR.toString(),
       accountId: SIGNVERIFYTESTS_ACCOUNT_ID,
       recipient,
-      message: "Test with FCAK, requireFullAccessKey=false",
       nonce: specificNonce,
     };
-    const authTokenString = await sign(signOptions);
+    const authTokenString = await sign("Test with FCAK, requireFullAccessKey=false", signOptions);
 
     const verifyOpts: VerifyOptions = {
       requireFullAccessKey: false,
@@ -159,10 +155,9 @@ describe("NEAR Signature Flow Integration Test", () => {
       signer: randomKeyPair.toString(),
       accountId: claimedAccountId,
       recipient,
-      message: "Test with random unassociated PK",
       nonce: specificNonce,
     };
-    const authTokenString = await sign(signOptions);
+    const authTokenString = await sign("Test with random unassociated PK", signOptions);
 
     await expect(
       verify(authTokenString, { expectedRecipient: recipient }),


### PR DESCRIPTION
See NEP:

https://github.com/near/NEPs/blob/master/neps/nep-0413.md

Major changes:

- [x] expose `SignedMessageParams`, `SignedMessage` types
- [x] `sign(options: SignOptions)` -> `sign(message: string, options: SignOptions)`
- [x] adds new SignOptions: `state`, advised for CSRF protection
- [x] add new VerifyOptions: `expectedMessage`, `validateMessage`, `validateRecipient`, `expectedState`, `validateState`
- [x] internally, serialize tag and SignedPayload separately, then append
- [x] no longer expose createAuthToken
- [x] update README, better cookbook